### PR TITLE
How to display failing tasks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,6 +187,15 @@ You most likely want to add a logging section to your ini for celery as well:
 
 and then update your ``[loggers]`` section to include it.
 
+Celery worker processes do not propagade exceptions inside tasks, but swallow them 
+silently by default. To see if your tasks fail you need to configure another logger:
+
+    # See https://github.com/celery/celery/issues/2437
+    [logger_celery_worker_job]
+    level = ERROR
+    handlers = console
+    qualname = celery.worker.job
+
 If you want use the default celery loggers then you can set
 **CELERYD_HIJACK_ROOT_LOGGER=True** in the [celery] section of your .ini
 

--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,8 @@ and then update your ``[loggers]`` section to include it.
 Celery worker processes do not propagade exceptions inside tasks, but swallow them 
 silently by default. To see if your tasks fail you need to configure another logger:
 
+.. code-block:: ini
+
     # See https://github.com/celery/celery/issues/2437
     [logger_celery_worker_job]
     level = ERROR


### PR DESCRIPTION
Celery is quiet by default and does not make it obvious if your tasks fail. One needs to know the specific logger which needs poking to see any failure output from worker processes.
